### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/src/main/java/org/apache/maven/plugins/site/render/AbstractSiteRenderingMojo.java
+++ b/src/main/java/org/apache/maven/plugins/site/render/AbstractSiteRenderingMojo.java
@@ -247,7 +247,7 @@ public abstract class AbstractSiteRenderingMojo extends AbstractSiteDescriptorMo
             mpir.setArtifactId("maven-project-info-reports-plugin");
             reportingPlugins.add(mpir);
         }
-        return reportingPlugins.toArray(new ReportPlugin[reportingPlugins.size()]);
+        return reportingPlugins.toArray(new ReportPlugin[0]);
     }
 
     protected SiteRenderingContext createSiteRenderingContext(Locale locale)


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:1005728060 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (1)
